### PR TITLE
[feat] RetryableTopics, DLQ, CircuitBreaker 구현

### DIFF
--- a/analysis-service/build.gradle
+++ b/analysis-service/build.gradle
@@ -46,7 +46,16 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // Circuit Breaker
-    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'   \
+
+    // AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     // DevTools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/KafkaDlqConsumer.java
+++ b/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/KafkaDlqConsumer.java
@@ -1,0 +1,44 @@
+package com.sparta.analysisservice.domain.product_analysis.infrastructure.messaging;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.analysisservice.domain.product_analysis.infrastructure.dto.UserActivityEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KafkaDlqConsumer {
+
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "user.event.dlq", groupId = "dlq-user-event-group")
+	public void listenUserEventDlq(String payload) {
+		UserActivityEvent event = deserialize(payload);
+		if (event != null) {
+			log.error("[DLQ 수신 - user.event.dlq] 비정상 처리된 이벤트 감지 -> {}", event);
+		}
+	}
+
+	@KafkaListener(topics = "product.analysis.dlq", groupId = "dlq-product-analysis-group")
+	public void listenProductAnalysisDlq(String payload) {
+		UserActivityEvent event = deserialize(payload);
+		if (event != null) {
+			log.error("[DLQ 수신 - product.analysis.dlq] Python 분석 파이프라인 전달 실패 이벤트 감지 -> {}", event);
+		}
+	}
+
+	private UserActivityEvent deserialize(String payload) {
+		try {
+			return objectMapper.readValue(payload, UserActivityEvent.class);
+		} catch (Exception e) {
+			log.error("DLQ 메시지 역직렬화 실패 → payload={}", payload, e);
+			return null;
+		}
+	}
+
+}

--- a/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/KafkaPublisher.java
+++ b/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/KafkaPublisher.java
@@ -3,6 +3,7 @@ package com.sparta.analysisservice.domain.product_analysis.infrastructure.messag
 import java.time.Instant;
 import java.util.UUID;
 
+import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Service;
 
@@ -21,38 +22,121 @@ public class KafkaPublisher {
 
 	private final KafkaTemplate<String, Object> kafkaTemplate;
 	private final ObjectMapper objectMapper;
+	private final CircuitBreakerFactory circuitBreakerFactory;
 
 	@CircuitBreaker(name = "kafkaPublishCB", fallbackMethod = "fallbackpublishUserEvent")
 	public void publishUserEvent(UUID sessionId, UUID productId, String eventType, String meta) {
+
 		UserActivityEvent event = UserActivityEvent.of(sessionId, productId, eventType, meta);
 
-		kafkaTemplate.send("user.event", event);
-		log.info("[PUBLISH → user.event] sessionId={}, eventType={}, productId={}, meta={}",
-			sessionId, eventType, productId, meta);
+		try {
+			String jsonPayload = objectMapper.writeValueAsString(event);
+			kafkaTemplate.send("user.event", jsonPayload);
+			log.info("[PUBLISH → user.event] sessionId={}, eventType={}, productId={}, meta={}",
+				sessionId, eventType, productId, meta);
+		} catch (JsonProcessingException e) {
+			log.error("Kafka 전송 실패 - JSON 직렬화 오류 sessionId={}, productId={}, error={}",
+				sessionId, productId, e.getMessage(), e);
+		}
 	}
 
-	@CircuitBreaker(name = "kafkaPublishCB", fallbackMethod = "fallbackPublishProductAnalysisEvent")
-	public void publishProductAnalysisEvent(UUID sessionId, UUID productId, Instant timestamp) throws
-		JsonProcessingException {
-		UserActivityEvent event = new UserActivityEvent(sessionId, productId, "CLICK", timestamp, null);
-
-		String data = objectMapper.writeValueAsString(event);
-		kafkaTemplate.send("product.analysis", data);
-		log.info("[PUBLISH → product.analysis] sessionId={}, productId={}, timestamp={}",
-			sessionId, productId, timestamp);
-	}
-
-	public void fallbackpublishUserEvent(UUID sessionId, UUID productId, Instant timestamp, Throwable e) {
+	public void fallbackpublishUserEvent(UUID sessionId, UUID productId, String eventType, String meta, Throwable e) {
 		log.error("Kafka user.event publish failed -> sessionId={}, productId={}, error={}",
 			sessionId, productId, e.getMessage(), e);
-		// 모니터링, dead-letter 큐 적재 등 필요 시 구현
+
+		// default 이벤트 객체
+		UserActivityEvent defaultEvent = UserActivityEvent.of(
+			sessionId != null ? sessionId : UUID.randomUUID(),
+			productId != null ? productId : UUID.fromString("00000000-0000-0000-0000-000000000000"),
+			eventType != null ? eventType : "UNKNOWN_EVENT",
+			meta != null ? meta : "DEFAULT_META"
+		);
+
+		// 1. 본 Topic으로 defaultEvent라도 무조건 재전송 (중단 방지 운영 목적)
+		try {
+			kafkaTemplate.send("user.event", defaultEvent);
+			log.warn("Fallback 기본 이벤트 재전송 완료 → user.event");
+		} catch (Exception ex) {
+			log.error("Fallback 본 Topic(user.event) 재전송 실패 — DLQ 처리로 전환 (sessionId={}, productId={}, eventType={})",
+				sessionId, productId, eventType, ex);
+		}
+
+		var dlqBreaker = circuitBreakerFactory.create("kafkaDlqBreaker");
+
+		dlqBreaker.run(
+			() -> {
+				String jsonPayload = null;
+				try {
+					jsonPayload = objectMapper.writeValueAsString(
+						UserActivityEvent.of(sessionId, productId, eventType, meta)
+					);
+				} catch (JsonProcessingException ex) {
+					log.error("DLQ 전송 실패 - JSON 직렬화 오류", e);
+				}
+				kafkaTemplate.send("user.event.dlq", jsonPayload);
+				log.warn("DLQ 전송 완료 → user.event.dlq");
+				return null;
+			}, throwable -> {
+				log.error("DLQ 전송도 실패 -> 회로 OPEN 가능성 있음 (Slack/문자 알림 필요)");
+				return null;
+			}
+		);
+
+		log.warn("DLQ로 이동 완료 => user.event.dlq");
+	}
+
+	//============================================================================================
+
+	@CircuitBreaker(name = "kafkaPublishCB", fallbackMethod = "fallbackPublishProductAnalysisEvent")
+	public void publishProductAnalysisEvent(UUID sessionId, UUID productId, Instant timestamp) {
+		UserActivityEvent event = new UserActivityEvent(sessionId, productId, "CLICK", timestamp, null);
+
+		try {
+			String data = objectMapper.writeValueAsString(event);
+			kafkaTemplate.send("product.analysis", data);
+			log.info("[PUBLISH → product.analysis] sessionId={}, productId={}, timestamp={}",
+				sessionId, productId, timestamp);
+		} catch (JsonProcessingException e) {
+			log.error("Kafka 전송 실패 - JSON 직렬화 오류 sessionId={}, productId={}, timestamp={}, error={}",
+				sessionId, productId, timestamp, e.getMessage(), e);
+		}
 	}
 
 	public void fallbackPublishProductAnalysisEvent(UUID sessionId, UUID productId, Instant timestamp,
 		Throwable e) {
 		log.error("[Fallback] product.analysis publish failed -> sessionId={}, productId={}, error={}",
 			sessionId, productId, e.getMessage(), e);
-		// 모니터링, dead-letter 큐 적재 등 필요 시 구현
+
+		UserActivityEvent defaultEvent = new UserActivityEvent(
+			sessionId != null ? sessionId : UUID.randomUUID(),
+			productId != null ? productId : UUID.fromString("00000000-0000-0000-0000-000000000000"),
+			"UNKNOWN_EVENT",
+			timestamp != null ? timestamp : Instant.now(),
+			"DEFAULT_META"
+		);
+
+		try {
+			String defaultData = objectMapper.writeValueAsString(defaultEvent);
+			kafkaTemplate.send("product.analysis", defaultData);
+			log.warn("Fallback 기본 이벤트 재전송 완료 → product.analysis");
+		} catch (Exception ex) {
+			log.error(
+				"Fallback 본 Topic(product.analysis) 재전송 실패 — DLQ로 대체 처리 진행 (sessionId={}, productId={}, timestamp={})",
+				sessionId, productId, timestamp, ex);
+		}
+
+		try {
+			String data = objectMapper.writeValueAsString(
+				new UserActivityEvent(sessionId, productId, "UNKNOWN_EVENT", timestamp, null)
+			);
+			kafkaTemplate.send("product.analysis.dlq", data);
+			log.warn("DLQ 저장 완료 → product.analysis.dlq");
+		} catch (JsonProcessingException ex) {
+			log.error("DLQ 메시지 직렬화 실패 → 운영자 알림 필요 | {}", ex.getMessage(), ex);
+		} catch (Exception ex) {
+			log.error("DLQ 전송조차 실패 → 운영자 알림 필요 | {}", ex.getMessage(), ex);
+		}
+
 	}
 
 }

--- a/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/UserEventConsumer.java
+++ b/analysis-service/src/main/java/com/sparta/analysisservice/domain/product_analysis/infrastructure/messaging/UserEventConsumer.java
@@ -10,8 +10,12 @@ import java.util.UUID;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.analysisservice.domain.product_analysis.application.service.ClickEventExtractor;
 import com.sparta.analysisservice.domain.product_analysis.domain.entity.UserEventDocument;
 import com.sparta.analysisservice.domain.product_analysis.domain.repository.UserEventRepository;
@@ -29,22 +33,41 @@ public class UserEventConsumer {
 	private final KafkaPublisher kafkaPublisher;
 	private final RedisTemplate<String, String> redisTemplate;
 	private final ClickEventExtractor clickEventExtractor;
+	private final ObjectMapper objectMapper;
 
 	private static final String SESSION_KEY_PREFIX = "user:session:";
 	private static final Duration SESSION_TTL = Duration.ofMinutes(10);
 
+	@RetryableTopic(
+		attempts = "3",
+		backoff = @Backoff(delay = 2000, multiplier = 2),
+		autoCreateTopics = "true",
+		dltTopicSuffix = ".dlq"
+	)
 	@KafkaListener(topics = "user.event", groupId = "user-group")
-	public void consume(UserActivityEvent event) {
-		logEventReceived(event);
+	public void consume(String payload) {
+		UserActivityEvent event;
 
-		if (!isSessionActive(event.sessionId())) {
-			startNewSession(event.sessionId());
-		} else {
-			refreshSessionTTL(event.sessionId());
+		try {
+			event = objectMapper.readValue(payload, UserActivityEvent.class);
+			logEventReceived(event);
+
+			if (!isSessionActive(event.sessionId())) {
+				startNewSession(event.sessionId());
+			} else {
+				refreshSessionTTL(event.sessionId());
+			}
+
+			saveEventToElasticsearch(event);
+			publishClickEvents();
+
+		} catch (JsonProcessingException e) {
+			log.error("Kafka 메시지 파싱 실패", e);
+			throw new RuntimeException("Kafka 메시지 처리 실패", e);
+		} catch (Exception e) {
+			log.error("Kafka 메시지 처리 중 예외 발생", e);
+			throw e;
 		}
-
-		saveEventToElasticsearch(event);
-		publishClickEvents();
 	}
 
 	// 로그

--- a/analysis-service/src/main/resources/application-actuator.yml
+++ b/analysis-service/src/main/resources/application-actuator.yml
@@ -1,0 +1,48 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+management:
+  health:
+    elasticsearch:
+      enabled: false
+  metrics:
+    enable:
+      process: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+
+management:
+  metrics:
+    enable:
+      process: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true

--- a/analysis-service/src/main/resources/application.yml
+++ b/analysis-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
       - kafka
       - elasticsearch
       - redis
+      - actuator
+
     active: test
 server:
   port: 8082

--- a/recommend-service/build.gradle
+++ b/recommend-service/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     // Circuitbreaker-Resilience4j
     implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
 
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
     // Feign Client
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
@@ -57,6 +60,9 @@ dependencies {
 
     // PGVector 타입
     implementation group: 'com.pgvector', name: 'pgvector', version: '0.1.6'
+
+    // Prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/KafkaDlqConsumer.java
+++ b/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/KafkaDlqConsumer.java
@@ -1,0 +1,55 @@
+package com.sparta.recommendservice.domain.product_vector.infrastructure.messaging;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.recommendservice.domain.product_vector.domain.event.EmbeddingUpdatedEvent;
+import com.sparta.recommendservice.domain.product_vector.domain.event.RecommendCompletedEvent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaDlqConsumer {
+
+	private final ObjectMapper objectMapper;
+
+	@KafkaListener(topics = "embedding.updated.dlq", groupId = "dlq-embedding-updated-group")
+	public void listendEmbeddingUpdatedDlq(String payload) {
+		EmbeddingUpdatedEvent event = deserialize(payload);
+		if (event != null) {
+			log.error("[DLQ 수신 - embedding.updated.dlq] 비정상 처리된 이벤트 감지 -> {}", event);
+		}
+	}
+
+	@KafkaListener(topics = "recommend.completed.dlq", groupId = "dlq-recommend-completed-group")
+	public void listenRecommendCompletedDlq(String payload) {
+		RecommendCompletedEvent event = deserializeRecommendCompletedEvent(payload);
+		if (event != null) {
+			log.error("[DLQ 수신 - recommend.completed.dlq] 추천 이벤트 비정상 처리 -> productId={}, recommendedIds={}",
+				event.productId(), event.recommendedIds());
+		}
+	}
+
+	private EmbeddingUpdatedEvent deserialize(String payload) {
+		try {
+			return objectMapper.readValue(payload, EmbeddingUpdatedEvent.class);
+		} catch (JsonProcessingException e) {
+			log.error("DLQ 메시지 역직렬화 실패 → payload={}", payload, e);
+			return null;
+		}
+	}
+
+	private RecommendCompletedEvent deserializeRecommendCompletedEvent(String payload) {
+		try {
+			return objectMapper.readValue(payload, RecommendCompletedEvent.class);
+		} catch (Exception e) {
+			log.error("DLQ 메시지 역직렬화 실패 → payload={}", payload, e);
+			return null;
+		}
+	}
+}

--- a/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/KafkaPublisher.java
+++ b/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/KafkaPublisher.java
@@ -34,6 +34,32 @@ public class KafkaPublisher {
 		}
 	}
 
+	public void fallbackPublishEmbeddingUpdated(List<UUID> productIds, Throwable e) {
+		log.error("Kafka embedding.updated publish failed -> size={}, error={}",
+			productIds != null ? productIds.size() : 0, e.getMessage(), e);
+
+		List<UUID> defaultIds = List.of();
+
+		try {
+			String defaultMessage = objectMapper.writeValueAsString(new EmbeddingUpdatedEvent(defaultIds));
+			kafkaTemplate.send("embedding.updated", defaultMessage);
+			log.info("Fallback: 디폴트 Kafka 메시지 전송 완료 -> size={}", defaultIds.size());
+		} catch (JsonProcessingException ex) {
+			log.error("Fallback Kafka 직렬화 실패", ex);
+		}
+
+		try {
+			String dlqMessage = objectMapper.writeValueAsString(new EmbeddingUpdatedEvent(productIds));
+			publishToDlq("embedding.updated.dlq", dlqMessage);
+
+		} catch (JsonProcessingException ex) {
+			log.error("DLQ Kafka 직렬화 실패 -> size={}, error={}",
+				productIds != null ? productIds.size() : 0, ex.getMessage(), ex);
+		}
+	}
+
+	// ======================================================================================
+
 	@CircuitBreaker(name = "kafkaPublishCB", fallbackMethod = "fallbackPublishRecommendCompleted")
 	public void publishRecommendCompleted(UUID productId, List<UUID> recommendedIds) {
 		try {
@@ -46,15 +72,25 @@ public class KafkaPublisher {
 		}
 	}
 
-	// Fallback Method
-	public void fallbackPublishEmbeddingUpdated(List<UUID> productIds, Throwable e) {
-		log.error("Kafka embedding.updated publish failed -> size={}, error={}",
-			productIds != null ? productIds.size() : 0, e.getMessage(), e);
-		// 알림, 모니터링, 재시도 큐 적재
-	}
-
 	public void fallbackPublishRecommendCompleted(UUID productId, List<UUID> recommendedIds, Throwable e) {
 		log.error("Kafka recommend.completed publish failed : {}", productId, e);
+
+		try {
+			String dlqMessage = objectMapper.writeValueAsString(new RecommendCompletedEvent(productId, recommendedIds));
+			publishToDlq("recommend.completed.dlq", dlqMessage);
+
+		} catch (JsonProcessingException ex) {
+			log.error("DLQ Kafka 직렬화 실패 -> productId={}, error={}", productId, ex.getMessage(), ex);
+		}
+	}
+
+	public void publishToDlq(String topic, String message) {
+		try {
+			kafkaTemplate.send(topic, message);
+			log.info("DLQ 메시지 전송 완료 -> topic={}, message={}", topic, message);
+		} catch (Exception e) {
+			log.error("DLQ 메시지 전송 실패 -> topic={}, message={}", topic, message, e);
+		}
 	}
 
 }

--- a/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/RecommendEventConsumer.java
+++ b/recommend-service/src/main/java/com/sparta/recommendservice/domain/product_vector/infrastructure/messaging/RecommendEventConsumer.java
@@ -5,6 +5,8 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -30,6 +32,12 @@ public class RecommendEventConsumer {
 	private final RecommendCacheService recommendCacheService;
 	private final ObjectMapper objectMapper;
 
+	@RetryableTopic(
+		attempts = "3",
+		backoff = @Backoff(delay = 2000, multiplier = 2),
+		autoCreateTopics = "true",
+		dltTopicSuffix = ".dlq"
+	)
 	@KafkaListener(topics = "embedding.updated")
 	public void handleEmbeddingUpdated(String message) {
 		EmbeddingUpdatedEvent event;
@@ -38,7 +46,7 @@ public class RecommendEventConsumer {
 			event = objectMapper.readValue(message, EmbeddingUpdatedEvent.class);
 		} catch (JsonProcessingException e) {
 			log.error("[KafkaListener] 메시지 변환 실패 -> message={}", message, e);
-			return; // 변환 실패 시 건너뜀
+			return;
 		}
 
 		List<UUID> productIds = event.productIds();
@@ -46,11 +54,10 @@ public class RecommendEventConsumer {
 
 		for (UUID productId : productIds) {
 			try {
-				// CircuitBreaker 적용
 				processRecommendation(productId);
 			} catch (Exception e) {
 				log.error("[KafkaListener] 추천 처리 실패 -> productId={}", productId, e);
-				// fallback 큐 적재나 알림 처리 가능
+				throw new RuntimeException("추천 처리 실패", e);
 			}
 		}
 	}
@@ -70,10 +77,19 @@ public class RecommendEventConsumer {
 		log.info("[Kafka] recommend.completed 이벤트 발행 -> productId={}, recommended={}", productId, recommended);
 	}
 
-	public void fallbackEmbeddingUpdated(EmbeddingUpdatedEvent event, Throwable e) {
-		List<UUID> productIds = event.productIds();
-		log.error("[Fallback] 추천 계산 또는 Redis 저장 실패, productIds={}, exception={}", productIds, e);
-		// 재시도 큐 적재, 모니터링, 알림 등
+	public void fallbackRecommendation(UUID productId, Throwable e) {
+		log.error("[Fallback] 추천 처리 실패 -> productId={}, exception={}", productId, e);
+
+		List<UUID> defaultRecommended = List.of();
+		recommendCacheService.saveRecommend(productId, defaultRecommended);
+		log.info("[Fallback] 디폴트 추천 결과 저장 -> productId={}, value={}", productId, defaultRecommended);
+
+		try {
+			String dlqMessage = objectMapper.writeValueAsString(new EmbeddingUpdatedEvent(List.of(productId)));
+			kafkaPublisher.publishToDlq("embedding.updated.dlq", dlqMessage);
+		} catch (JsonProcessingException ex) {
+			log.error("[Fallback] DLQ 직렬화 실패 -> productId={}", productId, ex);
+		}
 	}
 
 }

--- a/recommend-service/src/main/resources/application-actuator.yml
+++ b/recommend-service/src/main/resources/application-actuator.yml
@@ -1,0 +1,48 @@
+spring:
+  config:
+    activate:
+      on-profile: test
+
+management:
+  health:
+    elasticsearch:
+      enabled: false
+  metrics:
+    enable:
+      process: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+
+management:
+  metrics:
+    enable:
+      process: true
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    health:
+      show-details: always
+
+server:
+  tomcat:
+    mbeanregistry:
+      enabled: true

--- a/recommend-service/src/main/resources/application.yml
+++ b/recommend-service/src/main/resources/application.yml
@@ -8,6 +8,7 @@ spring:
       - redis
       - kafka
       - service
+      - actuator
     active: test
 server:
   port: 8081


### PR DESCRIPTION
### 연관이슈(#68 )
Closes #68 

### 변경사항
- CircuitBreaker로 디폴트 객체 전송을 통한 무중단 유지
- RetryableTopics로 리스너 재시도 구현
- 오류 발생 시 DLQ로 받을 수 있도록 리스너 구현 (추후 모니터링 지표 측정용)

### 리뷰요청
- CircuitBreaker의 fallback 메소드가 동작하는 것과 재시도가 3번 동작하는지에 대한 검증은 로컬에서 직접 호출을 통해 확인했습니다.

### 😊 리뷰 규칙을 지킵시다
코드 리뷰는 `Pn`룰에 따라 작성하기.   
Reviewer가 피드백을 남길 때 Assignee에게 얼마나 해당 피드백에 대해 강조하고 싶은 지 표현하기 위한 규칙입니다.
- `P1` : 꼭 반영해 주세요 (Request Changes) - 이슈가 발생하거나 취약점이 발견되는 케이스 등
- `P2` : 반영을 적극적으로 고려해 주시면 좋을 것 같아요 (Comment)
- `P3` : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다 (Chore)